### PR TITLE
Use CFBridgingRelease to transfer ownership to ARC

### DIFF
--- a/AudioProcessMonitor.m
+++ b/AudioProcessMonitor.m
@@ -98,7 +98,7 @@
                                       &bundleIDRef);
 
     if (status == noErr && bundleIDRef) {
-        NSString *bundleID = (NSString *)bundleIDRef;
+        NSString *bundleID = (NSString *)CFBridgingRelease(bundleIDRef);
         if (bundleID.length > 0) {
             [activeBundleIDs addObject:bundleID];
         }


### PR DESCRIPTION
Explicitly transfer ownership of the bundle string to ARC