### PR TITLE
Add noop for other platforms (Linux)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,18 @@
 let platform_utils;
 
+const noopPlatformUtils = {
+  getRunningInputAudioProcesses: () => {
+    return ['', ''];
+  }
+};
+
 if (process.platform === 'darwin') {
   platform_utils = require("bindings")("mac_utils.node");
 } else if (process.platform === 'win32') {
   platform_utils = require("bindings")("win_utils.node");
 } else {
-  throw new Error('Unsupported platform');
+  console.log('node-mac-utils Unsupported platform:', process.platform);
+  platform_utils = noopPlatformUtils;
 }
 
 module.exports = {

--- a/test.js
+++ b/test.js
@@ -19,7 +19,7 @@ async function runTests() {
             console.log('\nTesting Windows-specific functions:');
             // Add any Windows-specific function tests here
         } else {
-            console.log('Unsupported platform');
+            console.log('node-mac-utils Unsupported platform:', process.platform);
         }
 
         // Log all available exports


### PR DESCRIPTION
Some CI tests can run on Linux agents. This creates a simple noop for those cases.